### PR TITLE
Potential fix for code scanning alert no. 10: Incomplete URL substring sanitization

### DIFF
--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -70,8 +70,8 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 			const modelHostname = new URL(modelUrl).hostname
 			ark = modelHostname === "volces.com" || modelHostname.endsWith(".volces.com")
 		} catch {
-			// If the base URL is invalid, treat it as non-Ark.
-			ark = false
+			// If the base URL is invalid, ark remains false from its
+			// initialization, so no assignment is needed.
 		}
 		if (modelId.startsWith("o3-mini")) {
 			yield* this.handleO3FamilyMessage(modelId, systemPrompt, messages)

--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -65,7 +65,14 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 		const modelId = this.options.openAiModelId ?? ""
 		const enabledR1Format = this.options.openAiR1FormatEnabled ?? false
 		const deepseekReasoner = modelId.includes("deepseek-reasoner") || enabledR1Format
-		const ark = modelUrl.includes(".volces.com")
+		let ark = false
+		try {
+			const modelHostname = new URL(modelUrl).hostname
+			ark = modelHostname === "volces.com" || modelHostname.endsWith(".volces.com")
+		} catch {
+			// If the base URL is invalid, treat it as non-Ark.
+			ark = false
+		}
 		if (modelId.startsWith("o3-mini")) {
 			yield* this.handleO3FamilyMessage(modelId, systemPrompt, messages)
 			return


### PR DESCRIPTION
Potential fix for [https://github.com/canstralian/CodeFlux-AI-Kit/security/code-scanning/10](https://github.com/canstralian/CodeFlux-AI-Kit/security/code-scanning/10)

In general, the fix is to stop using `includes` on the entire URL string and instead parse the URL and inspect its `host` (or `hostname`) component. Then, compare that host against an explicit condition that correctly encodes “this host is exactly `volces.com` or a subdomain of it”. That avoids matches in the path, query, or in unrelated domains where `.volces.com` just appears as a substring.

Concretely for this code, we should:

1. Parse `modelUrl` with the standard `URL` constructor in a `try`/`catch`, similar to how `urlHost` is derived in the constructor.
2. Extract `hostname` (or `host`) from the parsed URL.
3. Set `ark` to `true` only if the hostname is exactly `volces.com` or ends with `.volces.com`.
4. Keep a safe default (`false`) if the URL cannot be parsed.

This minimizes behavior change: callers that previously used a proper `.volces.com` host will still satisfy the condition, while mis-specified URLs that merely contain `.volces.com` somewhere else will no longer trigger `ark`. All changes are within `src/api/providers/openai.ts` and only in the shown snippet around line 68; no new methods or external dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
